### PR TITLE
Add standalone empty-sequence side-effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 ## Motivation
 
-I dislike loops. Loops encourage imperative code, which I dislike even more so. Whenever I can, which is pretty much always but in the more performance-sensitive places, I very much rather using [LINQ][microsoft-linq] expressions instead. Still, LINQ has its limitatons.
+I don't like loops very much. Loops encourage imperative code, which I don't like very much either. Whenever possible, which is pretty much always but in the more performance-sensitive places, I very much rather using [LINQ][microsoft-linq] expressions instead.
+
+Still, LINQ has its limitatons.
 
 ## Overview
 
-*NoLoops* is a collection of extension methods for the [`IEnumerable<T>`][microsoft-ienumerable] and [`IAsyncEnumerable<T>`][microsoft-iasyncenumerable] interfaces, that I needed at one point and found  LINQ lacked.
+*NoLoops* is a collection of extension methods for the [`IEnumerable<T>`][microsoft-ienumerable] and [`IAsyncEnumerable<T>`][microsoft-iasyncenumerable] interfaces, that I needed at one point and found LINQ lacked.
 
 ## Using *NoLoops*
 

--- a/src/NoLoops/NoLoops.cs
+++ b/src/NoLoops/NoLoops.cs
@@ -33,6 +33,26 @@ namespace NoLoops;
 public static class NoLoops
 {
     /// <summary>
+    /// Returns an empty sequence that executes a side-effect when enumerated.
+    /// </summary>
+    /// <typeparam name="TSource">
+    /// The type of the elements of the resulting empty sequence.
+    /// </typeparam>
+    /// <param name="sideEffect">
+    /// An action with side-effects.
+    /// </param>
+    /// <returns>
+    /// An empty sequence that executes the given side-effect when enumerated.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The <paramref name="sideEffect"/> action is executed when the resulting empty sequence is enumerated.
+    /// </para>
+    /// </remarks>
+    public static IEnumerable<TSource> Do<TSource>(Action sideEffect)
+        => Enumerable.SideEffect<TSource>(sideEffect);
+
+    /// <summary>
     /// Executes a side-effect on every element of a sequence.
     /// </summary>
     /// <typeparam name="TSource">
@@ -442,4 +462,41 @@ public static class NoLoops
 
     [Pure]
     private static T Identity<T>(T value) => value;
+}
+
+file static class Enumerable
+{
+    public static IEnumerable<TSource> SideEffect<TSource>(Action sideEffect)
+        => new SideEffectEnumerable<TSource>(sideEffect);
+
+    private readonly struct SideEffectEnumerable<TSource>(Action sideEffect) : IEnumerable<TSource>
+    {
+        public IEnumerator<TSource> GetEnumerator()
+        {
+            sideEffect();
+
+            return Enumerator.Empty<TSource>();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}
+
+file static class Enumerator
+{
+    public static IEnumerator<TSource> Empty<TSource>()
+        => new EmptyEnumerator<TSource>();
+
+    private readonly struct EmptyEnumerator<TSource> : IEnumerator<TSource>
+    {
+        TSource IEnumerator<TSource>.Current => throw new InvalidOperationException();
+
+        object IEnumerator.Current => throw new InvalidOperationException();
+
+        bool IEnumerator.MoveNext() => false;
+
+        void IEnumerator.Reset() { }
+
+        void IDisposable.Dispose() { }
+    }
 }

--- a/tests/NoLoops.Tests/StandaloneSideEffectTests.cs
+++ b/tests/NoLoops.Tests/StandaloneSideEffectTests.cs
@@ -1,0 +1,33 @@
+namespace NoLoops.Tests;
+
+public class StandaloneSideEffectTests
+{
+    [Test]
+    public void ExecutesSideEffectUponEnumeration()
+        => Assert.Throws<Exception>(() => NoLoops.Do<int>(static () => throw new Exception("nasty side effect!")).ToList());
+
+    [Test]
+    public void ExecutesSideEffectUponEveryEnumeration()
+    {
+        var sideEffectsCount = 0;
+
+        var sideEffect = NoLoops.Do<string>(() => ++sideEffectsCount);
+
+        sideEffect.ToList();
+        sideEffect.ToList();
+        sideEffect.ToList();
+
+        Assert.That(sideEffectsCount, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void DoesNotExecuteSideEffectUponReturn()
+        => Assert.DoesNotThrow(() => NoLoops.Do<int>(static () => throw new Exception("nasty side effect!")));
+
+    [Test]
+    public void DoesNotExecuteSideEffectIfNotEnumerated()
+        => Assert.DoesNotThrow(static () => new[] { 1, 2, 3 }
+            .Concat(NoLoops.Do<int>(static () => throw new Exception("nasty side effect!")))
+            .Take(2)
+            .ToList());
+}


### PR DESCRIPTION
This PR adds standalone side-effects in the form of a `Do` factory method.